### PR TITLE
Do not assign to read only property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
-
+  - "0.12"
+  - "iojs"
+before_install:
+  - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ] ; then npm install -g npm@2.7.0; fi'
 services: redis
-
 notifications:
   irc: "irc.freenode.org#observing"

--- a/index.js
+++ b/index.js
@@ -658,12 +658,6 @@ Leverage.introduce = function introduce(directory, obj) {
       var args = slice.call(arguments, 0);
       return this._.seval(script, args);
     };
-
-    //
-    // Reset the function name to the name of the script which will hopefully
-    // improve stack traces.
-    //
-    obj[script.name].name = script.name;
   });
 
   return scripts;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Leverage is a thin wrapper around the `redis` client that integrates your lua scripts as methods AND supports reliable and fault tolerant Pub/Sub on top of redis.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha $(find test -name '*.test.js') --ui bdd --reporter spec",
-    "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/*.test.js --reporter spec --ui bdd test.js"
+    "test": "mocha $(find test -name '*.test.js')",
+    "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -25,16 +25,16 @@
   "author": "Arnout Kazemier <opensource@observe.it>",
   "license": "MIT",
   "devDependencies": {
-    "chai": "1.9.x",
+    "chai": "2.1.x",
     "istanbul": "0.3.x",
-    "mocha": "2.0.x",
-    "pre-commit": "0.0.x",
+    "mocha": "2.2.x",
+    "pre-commit": "1.0.x",
     "redis": "0.12.x"
   },
   "dependencies": {
     "diagnostics": "0.0.x",
     "eventemitter3": "0.1.x",
-    "fusing": "0.4.0",
+    "fusing": "1.0.x",
     "underverse": "0.1.x"
   }
 }

--- a/test/lua.test.js
+++ b/test/lua.test.js
@@ -32,15 +32,18 @@ describe('lua', function () {
     it('should only send messages for the given channel', function (done) {
       var client = leverage(true);
 
-      client.subscribe('foos', { replay: 0 }).on('foos::message', function (msg, id) {
-        expect(msg).to.equal('foo');
-        expect(id).to.equal(1);
+      client.subscribe('foos', { replay: 0 });
+      client.once('foos::online', function () {
+        client.on('foos::message', function (msg, id) {
+          expect(msg).to.equal('foo');
+          expect(id).to.equal(1);
 
-        client.destroy();
-        done();
+          client.destroy();
+          done();
+        });
+
+        client.publish('foos', 'foo');
       });
-
-      client.publish('foos', 'foo');
     });
 
     it('should increase and return the private counter', function (done) {


### PR DESCRIPTION
In `strict` mode assigning to a read only property (Function.name) results in an error.